### PR TITLE
Remove AppBackground background image from config

### DIFF
--- a/mock/src/config.js
+++ b/mock/src/config.js
@@ -1,7 +1,5 @@
 export default {
   brand: {
-    backgroundImage:
-      'http://tacombi.com/system/uploads/gallery_image/image/40/gallery-events-tacombi-flatiron.jpg',
     brandColor: '#68070A',
     textColor: 'white',
     links: [

--- a/src/App.js
+++ b/src/App.js
@@ -65,7 +65,7 @@ class App extends Component {
           <Nav brand={brand} customer={customer} />
           <SystemNotifications />
           <div className="container">
-            <AppBackground />
+            <AppBackground brand={brand} />
             <Routes />
           </div>
           <div className="CartButton__container fixed b0 r0 mr1 md:mr3 mb1 md:col-6 lg:col-5 z1">

--- a/src/components/AppBackground/index.js
+++ b/src/components/AppBackground/index.js
@@ -1,12 +1,21 @@
 import { PureComponent } from 'react';
 import { withRouter } from 'react-router-dom';
 import RegistryLoader from 'lib/RegistryLoader';
+import BrandModel from 'constants/Models/BrandModel';
 
 class AppBackground extends PureComponent {
-  render() {
-    const { location } = this.props;
+  static propTypes = {
+    brand: BrandModel.propTypes
+  };
 
-    return RegistryLoader({ location }, 'components.AppBackground', () =>
+  static defaultProps = {
+    brand: BrandModel.defaultProps
+  };
+
+  render() {
+    const { location, brand } = this.props;
+
+    return RegistryLoader({ location, brand }, 'components.AppBackground', () =>
       import('./presentation.js')
     );
   }

--- a/src/components/AppBackground/presentation.js
+++ b/src/components/AppBackground/presentation.js
@@ -3,7 +3,7 @@ import get from 'utils/get';
 import getRoutes from 'utils/getRoutes';
 import { Image } from 'components';
 
-const AppBackground = React.memo(({ location, brandContext }) => {
+const AppBackground = React.memo(({ location, brand }) => {
   const RoutesWithBackground = [
     getRoutes().WELCOME,
     getRoutes().LOGIN,
@@ -23,7 +23,7 @@ const AppBackground = React.memo(({ location, brandContext }) => {
     <Image
       className="fixed t0 l0 r0 b0 z-1"
       isBg={true}
-      src={get(brandContext, 'backgroundImage')}
+      src={get(brand, 'large_image')}
     />
   );
 });

--- a/src/config.js
+++ b/src/config.js
@@ -16,8 +16,6 @@ import OrderSummaryContainer from 'containers/OrderSummaryContainer';
 
 export const defaultConfig = {
   brand: {
-    backgroundImage: '',
-    logoImage: '',
     links: [
       {
         name: 'Privacy Policy',


### PR DESCRIPTION
Hey, @joshiefishbein. I took a crack at moving the app background image to being pulled from the cloud instead of coming from the config file. Can you please take a look and let me know if I did this correctly?

I have a couple of questions about proptypes:

1. I was using Nav/index.js as an example for doing this, but the `Nav` component is a stateless component while `AppBackground` is Class Component, so I used the `static propTypes` approach and kept the `propType` definitions out of the presentational component. Is this the correct way to do it?
1. We don't have a propType definition for the `location` prop. Should we or is that intentional?

Thanks in advance for your help with this!